### PR TITLE
Implement `Send` for `Image`

### DIFF
--- a/pixman/src/image/mod.rs
+++ b/pixman/src/image/mod.rs
@@ -190,7 +190,7 @@ macro_rules! image_type {
             /// used as a src in a blit operation
             pub fn set_alpha_map<'alpha: 'a>(
                 self,
-                alpha_map: &'alpha crate::Image<'_, 'static>,
+                alpha_map: crate::Image<'alpha, 'static>,
                 x: i16,
                 y: i16,
             ) -> $name<'alpha> {


### PR DESCRIPTION
This changes the assumptions of the crate to assert that a valid `pixmap::Image` has a ref-count of 1, with an alpha map that has a ref-count of 1. Consequently, `set_alpha_map` must take ownership of its argument.

My understanding, looking at the pixmap code, is that this should ensure it is safe to `Send` the `Image` to another thread. Of course this does limit the API of this crate if a consumer wants to use multiple references (though `pixman_image_ref` wasn't wrapper already), or wants to use `set_alpha_map` while still keeping a reference to the alpha map. The first issue can just be solved by wrapping in `Rc`, though.

https://github.com/Smithay/smithay/issues/1500