### PR TITLE
Rename `composite32` to `composite`, instead of having both

### DIFF
--- a/pixman/examples/alpha.rs
+++ b/pixman/examples/alpha.rs
@@ -64,7 +64,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        ((10 * WIDTH) as u16, HEIGHT as u16),
+        ((10 * WIDTH) as i32, HEIGHT as i32),
     );
 
     let src_img = src_img.set_alpha_map(&alpha_img, 10, 10);
@@ -76,7 +76,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        ((10 * WIDTH) as u16, HEIGHT as u16),
+        ((10 * WIDTH) as i32, HEIGHT as i32),
     );
 
     let mut out_img = Image::new(
@@ -93,7 +93,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dest_img.width() as u16, dest_img.height() as u16),
+        (dest_img.width() as i32, dest_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/checkerboard.rs
+++ b/pixman/examples/checkerboard.rs
@@ -36,8 +36,8 @@ pub fn main() {
                 None,
                 (0, 0),
                 (0, 0),
-                ((j * TILE_SIZE) as i16, (i * TILE_SIZE) as i16),
-                (TILE_SIZE as u16, TILE_SIZE as u16),
+                ((j * TILE_SIZE) as i32, (i * TILE_SIZE) as i32),
+                (TILE_SIZE as i32, TILE_SIZE as i32),
             );
         }
     }
@@ -54,7 +54,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (WIDTH as u16, HEIGHT as u16),
+        (WIDTH as i32, HEIGHT as i32),
     );
 
     let mut out_img = Image::new(
@@ -71,7 +71,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (destination.width() as u16, destination.height() as u16),
+        (destination.width() as i32, destination.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/clip.rs
+++ b/pixman/examples/clip.rs
@@ -39,7 +39,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (WIDTH as u16, HEIGHT as u16),
+        (WIDTH as i32, HEIGHT as i32),
     );
 
     let clip_region = Region32::init_rect(50, 0, 100, 200);
@@ -67,7 +67,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (WIDTH as u16, HEIGHT as u16),
+        (WIDTH as i32, HEIGHT as i32),
     );
 
     let mut out_img = Image::new(
@@ -84,7 +84,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dst_img.width() as u16, dst_img.height() as u16),
+        (dst_img.width() as i32, dst_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/conical.rs
+++ b/pixman/examples/conical.rs
@@ -30,7 +30,7 @@ pub fn main() {
         src_img.set_repeat(Repeat::Normal);
         src_img.set_transform(transform).unwrap();
 
-        dest_img.composite32(
+        dest_img.composite(
             Operation::Over,
             &src_img,
             None,
@@ -55,7 +55,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dest_img.width() as u16, dest_img.height() as u16),
+        (dest_img.width() as i32, dest_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(
@@ -100,7 +100,7 @@ fn draw_checkerboard(image: &mut Image<'_, '_>, check_size: usize, color1: u32, 
         for i in 0..n_checks_x {
             let src = if ((i ^ j) & 1) == 1 { &c1 } else { &c2 };
 
-            image.composite32(
+            image.composite(
                 Operation::Src,
                 src,
                 None,

--- a/pixman/examples/gradient.rs
+++ b/pixman/examples/gradient.rs
@@ -43,7 +43,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        ((10 * WIDTH) as u16, HEIGHT as u16),
+        ((10 * WIDTH) as i32, HEIGHT as i32),
     );
 
     let mut out_img = Image::new(
@@ -60,7 +60,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dest_img.width() as u16, dest_img.height() as u16),
+        (dest_img.width() as i32, dest_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/solid_fill.rs
+++ b/pixman/examples/solid_fill.rs
@@ -22,7 +22,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dst.width() as u16, dst.height() as u16),
+        (dst.width() as i32, dst.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/trap.rs
+++ b/pixman/examples/trap.rs
@@ -39,7 +39,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (WIDTH as u16, HEIGHT as u16),
+        (WIDTH as i32, HEIGHT as i32),
     );
 
     let mut out_img = Image::new(
@@ -56,7 +56,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dest_img.width() as u16, dest_img.height() as u16),
+        (dest_img.width() as i32, dest_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/examples/tri.rs
+++ b/pixman/examples/tri.rs
@@ -52,7 +52,7 @@ pub fn main() {
         (0, 0),
         (0, 0),
         (0, 0),
-        (dest_img.width() as u16, dest_img.height() as u16),
+        (dest_img.width() as i32, dest_img.height() as i32),
     );
 
     let image_buffer = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(

--- a/pixman/src/image/bits.rs
+++ b/pixman/src/image/bits.rs
@@ -270,42 +270,6 @@ impl Image<'_, '_> {
         operation: Operation,
         src: &ImageRef,
         mask: Option<&ImageRef>,
-        src_loc: (i16, i16),
-        mask_loc: (i16, i16),
-        dest_loc: (i16, i16),
-        size: (u16, u16),
-    ) {
-        let mask_ptr = if let Some(mask) = mask {
-            mask.as_ptr()
-        } else {
-            std::ptr::null_mut()
-        };
-
-        unsafe {
-            ffi::pixman_image_composite(
-                operation.into(),
-                src.as_ptr(),
-                mask_ptr,
-                self.as_ptr(),
-                src_loc.0,
-                src_loc.1,
-                mask_loc.0,
-                mask_loc.1,
-                dest_loc.0,
-                dest_loc.1,
-                size.0,
-                size.1,
-            )
-        }
-    }
-
-    /// Composite the specified src image into this image
-    #[allow(clippy::too_many_arguments)]
-    pub fn composite32(
-        &mut self,
-        operation: Operation,
-        src: &ImageRef,
-        mask: Option<&ImageRef>,
         src_loc: (i32, i32),
         mask_loc: (i32, i32),
         dest_loc: (i32, i32),


### PR DESCRIPTION
The `composite` function in Pixman is defined to just call `composite32` (for compatibility with ancient code from before that was added). So there's no need to expose both in Rust bindings.

This is a breaking API change.

I'm not sure if `Region16` is useful to keep as a type, or just unnecessary. Internally, Pixman just uses `pixman_region32_copy_from_region16` to convert it to a `Region32`...